### PR TITLE
Also require ISA-L on macos

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,13 @@ test:
     - xopen
 
 about:
-  home: https://github.com/marcelm/xopen/
+  home: https://github.com/pycompression/xopen/
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: Open compressed files transparently in Python
-  doc_url: https://github.com/marcelm/xopen/
-  dev_url: https://github.com/marcelm/xopen/
+  doc_url: https://github.com/pycompression/xopen/
+  dev_url: https://github.com/pycompression/xopen/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - python-isal  # [unix and not (python_impl == 'pypy')]
+    - python-isal  # [unix and python_impl != 'pypy']
     - isa-l  # [unix]
     - pigz
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 38277eb96313b2e8822e19e793791801a1f41bf13ee5b48616a97afc65e9adb3
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -21,8 +21,8 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - python-isal  # [linux and not (python_impl == 'pypy')]
-    - isa-l  # [linux]
+    - python-isal  # [unix and not (python_impl == 'pypy')]
+    - isa-l  # [unix]
     - pigz
 
 test:


### PR DESCRIPTION
ISA-L has recently become available on MacOS via conda. It was some work but it was doable. Windows though... It really is a third-class citizen when it comes to building software to get your work done. I am working on that in my spare time, as it has no relevance to my work (we use linux exclusively) whatsoever. At least also mac is supported now. So most of the developer crowd should be on board.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
